### PR TITLE
Add ForStates to configure multiple states

### DIFF
--- a/DStateMachine.Core/DStateMachine.cs
+++ b/DStateMachine.Core/DStateMachine.cs
@@ -50,6 +50,19 @@ namespace DStateMachine
             return new StateConfiguration<TTrigger, TState>(state, this);
         }
 
+        /// <summary>
+        /// Begins configuration for multiple states.
+        /// Each configured action or transition will be applied to all provided states.
+        /// </summary>
+        public MultiStateConfiguration<TTrigger, TState> ForStates(params TState[] states)
+        {
+            foreach (var state in states)
+            {
+                GetOrCreateStateActions(state);
+            }
+            return new MultiStateConfiguration<TTrigger, TState>(states, this);
+        }
+
         public DStateMachine<TTrigger, TState> DefaultOnEntry(Func<DStateMachine<TTrigger, TState>, Task> action)
         {
             _defaultEntryActions.Add(action);

--- a/DStateMachine.Core/MultiStateConfiguration.cs
+++ b/DStateMachine.Core/MultiStateConfiguration.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DStateMachine
+{
+    /// <summary>
+    /// Fluent configuration for multiple states at once.
+    /// Allows applying the same entry, exit and trigger configuration
+    /// to a collection of states.
+    /// </summary>
+    public class MultiStateConfiguration<TTrigger, TState>
+    {
+        private readonly IReadOnlyCollection<TState> _states;
+        private readonly DStateMachine<TTrigger, TState> _machine;
+
+        internal MultiStateConfiguration(IEnumerable<TState> states, DStateMachine<TTrigger, TState> machine)
+        {
+            _states = states.ToArray();
+            _machine = machine;
+        }
+
+        /// <summary>
+        /// Gets the underlying state machine.
+        /// </summary>
+        public DStateMachine<TTrigger, TState> Machine => _machine;
+
+        public MultiStateConfiguration<TTrigger, TState> IgnoreDefaultEntry()
+        {
+            foreach (var state in _states)
+                _machine.GetOrCreateStateActions(state).IgnoreDefaultEntry = true;
+            return this;
+        }
+
+        public MultiStateConfiguration<TTrigger, TState> IgnoreDefaultExit()
+        {
+            foreach (var state in _states)
+                _machine.GetOrCreateStateActions(state).IgnoreDefaultExit = true;
+            return this;
+        }
+
+        public MultiStateConfiguration<TTrigger, TState> OnEntry(Action<DStateMachine<TTrigger, TState>> action)
+        {
+            foreach (var state in _states)
+                _machine.ForState(state).OnEntry(action);
+            return this;
+        }
+
+        public MultiStateConfiguration<TTrigger, TState> OnEntry(Func<Task> action)
+        {
+            foreach (var state in _states)
+                _machine.ForState(state).OnEntry(action);
+            return this;
+        }
+
+        public MultiStateConfiguration<TTrigger, TState> OnEntry(Func<DStateMachine<TTrigger, TState>, Task> asyncAction)
+        {
+            foreach (var state in _states)
+                _machine.ForState(state).OnEntry(asyncAction);
+            return this;
+        }
+
+        public MultiStateConfiguration<TTrigger, TState> OnExit(Action<DStateMachine<TTrigger, TState>> action)
+        {
+            foreach (var state in _states)
+                _machine.ForState(state).OnExit(action);
+            return this;
+        }
+
+        public MultiStateConfiguration<TTrigger, TState> OnExit(Func<Task> action)
+        {
+            foreach (var state in _states)
+                _machine.ForState(state).OnExit(action);
+            return this;
+        }
+
+        public MultiStateConfiguration<TTrigger, TState> OnExit(Func<DStateMachine<TTrigger, TState>, Task> asyncAction)
+        {
+            foreach (var state in _states)
+                _machine.ForState(state).OnExit(asyncAction);
+            return this;
+        }
+
+        public MultiStateConfiguration<TTrigger, TState> OnTrigger(TTrigger trigger, Action<TransitionBuilder<TTrigger, TState>> config)
+        {
+            foreach (var state in _states)
+            {
+                var builder = new TransitionBuilder<TTrigger, TState>(state, trigger, _machine);
+                config(builder);
+                builder.Build();
+            }
+            return this;
+        }
+    }
+}

--- a/DStateMachine.Tests/DStateMachineTests.cs
+++ b/DStateMachine.Tests/DStateMachineTests.cs
@@ -391,6 +391,23 @@ namespace Tests
             Assert.Equal(TestState.B, sm.CurrentState);
         }
 
+        [Fact]
+        public void MultiStateConfiguration_TriggerFromAnyState_Test()
+        {
+            var sm = new DStateMachine<string, string>("A");
+            sm.ForStates("A", "B").OnTrigger("go", tb => tb.ChangeState("C"));
+            sm.ForState("C").OnEntry(() => Task.CompletedTask);
+
+            sm.Trigger("go");
+            Assert.Equal("C", sm.CurrentState);
+
+            var sm2 = new DStateMachine<string, string>("B");
+            sm2.ForStates("A", "B").OnTrigger("go", tb => tb.ChangeState("C"));
+            sm2.ForState("C").OnEntry(() => Task.CompletedTask);
+            sm2.Trigger("go");
+            Assert.Equal("C", sm2.CurrentState);
+        }
+
         #endregion
     }
 }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ sm.ForState("B").OnEntry(() => Console.WriteLine("Entered B"));
 
 await sm.TriggerAsync("toB");
 Console.WriteLine(sm.CurrentState); // Output: B
+
+// Configure a trigger for multiple states at once
+sm.ForStates("A", "B").OnTrigger("reset", tb => tb.ChangeState("A"));
 ```
 
 ---
@@ -141,7 +144,7 @@ Console.WriteLine(dot);
 
 1. Clone the repository or add the files to your project.
 2. Create a new instance: `new DStateMachine<TTrigger, TState>(initialState)`.
-3. Configure states using `.ForState(state)` and chain `OnEntry`, `OnExit`, and `OnTrigger`.
+3. Configure states using `.ForState(state)` or `.ForStates(state1, state2, ...)` and chain `OnEntry`, `OnExit`, and `OnTrigger`.
 4. Fire transitions using `Trigger(trigger)` or `await TriggerAsync(trigger)`.
 
 ---


### PR DESCRIPTION
## Summary
- add `MultiStateConfiguration` for configuring multiple states at once
- expose `ForStates` helper in `DStateMachine`
- document usage of `ForStates` in README
- test multi-state configuration